### PR TITLE
Enhance task and focus session models with statistics support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:ai_test/providers/stats_provider.dart';
 import 'package:ai_test/services/notification_service.dart';
 import 'package:ai_test/providers/focus_provider.dart';
 import 'package:ai_test/providers/profile_provider.dart';
@@ -30,6 +31,7 @@ void main() async {
         ChangeNotifierProvider(create: (context) => TaskProvider()..loadTasks()),
         ChangeNotifierProvider(create: (context) => JournalProvider()..loadEntries()),
         ChangeNotifierProvider(create: (context) => FocusProvider()),
+        ChangeNotifierProvider(create: (context) => StatsProvider()..loadStats()),
       ],
       child: const MyApp(),
     ),
@@ -48,8 +50,8 @@ class MyApp extends StatelessWidget {
         return MaterialApp(
           title: 'FocusFlow Assistant',
           debugShowCheckedModeBanner: false,
-          theme: AppThemes.lightTheme(themeNotifier.primarySwatch),
-          darkTheme: AppThemes.darkTheme(themeNotifier.primarySwatch),
+          theme: AppThemes.lightTheme(themeNotifier.primarySwatch, themeNotifier.fontSize),
+          darkTheme: AppThemes.darkTheme(themeNotifier.primarySwatch, themeNotifier.fontSize),
           themeMode: themeNotifier.themeMode,
           localizationsDelegates: const [
             GlobalMaterialLocalizations.delegate,

--- a/lib/models/focus_session.dart
+++ b/lib/models/focus_session.dart
@@ -1,0 +1,27 @@
+class FocusSession {
+  final int? id;
+  final int durationMinutes;
+  final DateTime createdAt;
+
+  FocusSession({
+    this.id,
+    required this.durationMinutes,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'durationMinutes': durationMinutes,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+
+  factory FocusSession.fromMap(Map<String, dynamic> map) {
+    return FocusSession(
+      id: map['id'],
+      durationMinutes: map['durationMinutes'],
+      createdAt: DateTime.parse(map['createdAt']),
+    );
+  }
+}

--- a/lib/models/todo_task.dart
+++ b/lib/models/todo_task.dart
@@ -6,6 +6,7 @@ class TodoTask {
   final String description;
   final bool isCompleted;
   final DateTime createdAt;
+  final DateTime? completedAt;
   final int estimatedMinutes;
   final int urgency; // 1 (bas) à 5 (critique)
   final List<String> subTasks;
@@ -16,6 +17,7 @@ class TodoTask {
     this.description = '',
     this.isCompleted = false,
     DateTime? createdAt,
+    this.completedAt,
     this.estimatedMinutes = 15,
     this.urgency = 3,
     this.subTasks = const [],
@@ -28,6 +30,7 @@ class TodoTask {
       'description': description,
       'isCompleted': isCompleted ? 1 : 0,
       'createdAt': createdAt.toIso8601String(),
+      'completedAt': completedAt?.toIso8601String(),
       'estimatedMinutes': estimatedMinutes,
       'urgency': urgency,
       'subTasks': jsonEncode(subTasks),
@@ -41,6 +44,7 @@ class TodoTask {
       description: map['description'] ?? '',
       isCompleted: map['isCompleted'] == 1,
       createdAt: DateTime.parse(map['createdAt']),
+      completedAt: map['completedAt'] != null ? DateTime.parse(map['completedAt']) : null,
       estimatedMinutes: map['estimatedMinutes'] ?? 15,
       urgency: map['urgency'] ?? 3,
       subTasks: List<String>.from(jsonDecode(map['subTasks'] ?? '[]')),
@@ -53,6 +57,7 @@ class TodoTask {
     String? description,
     bool? isCompleted,
     DateTime? createdAt,
+    DateTime? completedAt,
     int? estimatedMinutes,
     int? urgency,
     List<String>? subTasks,
@@ -63,6 +68,7 @@ class TodoTask {
       description: description ?? this.description,
       isCompleted: isCompleted ?? this.isCompleted,
       createdAt: createdAt ?? this.createdAt,
+      completedAt: completedAt ?? this.completedAt,
       estimatedMinutes: estimatedMinutes ?? this.estimatedMinutes,
       urgency: urgency ?? this.urgency,
       subTasks: subTasks ?? this.subTasks,

--- a/lib/others/app_theme.dart
+++ b/lib/others/app_theme.dart
@@ -151,13 +151,13 @@ class AppThemes {
     return MaterialColor(color.toARGB32(), swatch);
   }
 
-  static ThemeData lightTheme(MaterialColor primarySwatch) {
+  static ThemeData lightTheme(MaterialColor primarySwatch, double fontSizeFactor) {
     final colorScheme = ColorScheme.fromSwatch(
       primarySwatch: primarySwatch,
       brightness: Brightness.light,
-      accentColor: primarySwatch[400],
     ).copyWith(
       surface: Colors.white,
+      secondary: primarySwatch[400],
     );
 
     return ThemeData(
@@ -165,7 +165,7 @@ class AppThemes {
       brightness: Brightness.light,
       primarySwatch: primarySwatch,
       colorScheme: colorScheme,
-      scaffoldBackgroundColor: colorScheme.surface,
+      scaffoldBackgroundColor: const Color(0xFFF8F9FA),
       cardTheme: CardThemeData(
         color: Colors.white,
         elevation: 0,
@@ -175,12 +175,12 @@ class AppThemes {
         ),
       ),
       appBarTheme: AppBarTheme(
-        backgroundColor: colorScheme.surface,
+        backgroundColor: const Color(0xFFF8F9FA),
         foregroundColor: Colors.black87,
         elevation: 0,
         centerTitle: true,
         titleTextStyle: GoogleFonts.poppins(
-          fontSize: 18,
+          fontSize: 18 * fontSizeFactor,
           fontWeight: FontWeight.bold,
           color: Colors.black87,
         ),
@@ -190,6 +190,7 @@ class AppThemes {
         ThemeData.light().textTheme.apply(
               bodyColor: Colors.black87,
               displayColor: Colors.black,
+              fontSizeFactor: fontSizeFactor,
             ),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
@@ -199,7 +200,10 @@ class AppThemes {
           elevation: 0,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-          textStyle: GoogleFonts.poppins(fontWeight: FontWeight.w600, fontSize: 15),
+          textStyle: GoogleFonts.poppins(
+            fontWeight: FontWeight.w600, 
+            fontSize: 15 * fontSizeFactor
+          ),
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(
@@ -218,19 +222,19 @@ class AppThemes {
           borderRadius: BorderRadius.circular(16),
           borderSide: BorderSide(color: primarySwatch, width: 2),
         ),
-        hintStyle: GoogleFonts.poppins(color: Colors.grey[400], fontSize: 14),
-        labelStyle: GoogleFonts.poppins(color: Colors.black87, fontSize: 14),
+        hintStyle: GoogleFonts.poppins(color: Colors.grey[400], fontSize: 14 * fontSizeFactor),
+        labelStyle: GoogleFonts.poppins(color: Colors.black87, fontSize: 14 * fontSizeFactor),
       ),
     );
   }
 
-  static ThemeData darkTheme(MaterialColor primarySwatch) {
+  static ThemeData darkTheme(MaterialColor primarySwatch, double fontSizeFactor) {
     final colorScheme = ColorScheme.fromSwatch(
       primarySwatch: primarySwatch,
       brightness: Brightness.dark,
-      accentColor: primarySwatch[200],
     ).copyWith(
       surface: const Color(0xFF1E1E1E),
+      secondary: primarySwatch[200],
     );
 
     return ThemeData(
@@ -253,7 +257,7 @@ class AppThemes {
         elevation: 0,
         centerTitle: true,
         titleTextStyle: GoogleFonts.poppins(
-          fontSize: 18,
+          fontSize: 18 * fontSizeFactor,
           fontWeight: FontWeight.bold,
           color: Colors.white,
         ),
@@ -263,6 +267,7 @@ class AppThemes {
         ThemeData.dark().textTheme.apply(
               bodyColor: Colors.white70,
               displayColor: Colors.white,
+              fontSizeFactor: fontSizeFactor,
             ),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
@@ -272,7 +277,10 @@ class AppThemes {
           elevation: 0,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-          textStyle: GoogleFonts.poppins(fontWeight: FontWeight.w600, fontSize: 15),
+          textStyle: GoogleFonts.poppins(
+            fontWeight: FontWeight.w600, 
+            fontSize: 15 * fontSizeFactor
+          ),
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(
@@ -291,8 +299,8 @@ class AppThemes {
           borderRadius: BorderRadius.circular(16),
           borderSide: BorderSide(color: primarySwatch, width: 2),
         ),
-        hintStyle: GoogleFonts.poppins(color: Colors.grey[600], fontSize: 14),
-        labelStyle: GoogleFonts.poppins(color: Colors.white70, fontSize: 14),
+        hintStyle: GoogleFonts.poppins(color: Colors.grey[600], fontSize: 14 * fontSizeFactor),
+        labelStyle: GoogleFonts.poppins(color: Colors.white70, fontSize: 14 * fontSizeFactor),
       ),
     );
   }

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -42,8 +42,9 @@ class _SettingsState extends State<Settings> {
 
   // Fonction pour afficher le dialogue de sélection de couleur
   void showColorPickerDialog() {
-    Color pickerColor =
-        Provider.of<ThemeNotifier>(context, listen: false).primarySwatch;
+    final themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
+    Color pickerColor = themeNotifier.primarySwatch;
+    
     showDialog(
       context: context,
       builder: (context) {
@@ -66,15 +67,12 @@ class _SettingsState extends State<Settings> {
               ),
               actions: [
                 TextButton(
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
+                  onPressed: () => Navigator.of(context).pop(),
                   child: const Text('Annuler'),
                 ),
                 ElevatedButton(
                   onPressed: () {
-                    Provider.of<ThemeNotifier>(context, listen: false)
-                        .changeThemeColor(pickerColor);
+                    themeNotifier.changeThemeColor(pickerColor);
                     Navigator.of(context).pop();
                   },
                   child: const Text('Appliquer'),
@@ -112,9 +110,7 @@ class _SettingsState extends State<Settings> {
           ),
           actions: [
             TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
+              onPressed: () => Navigator.of(context).pop(),
               child: const Text('Annuler'),
             ),
             ElevatedButton(
@@ -125,8 +121,9 @@ class _SettingsState extends State<Settings> {
                     Navigator.of(context).pop();
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                          content: Text('Clé API mise à jour.',
-                              style: GoogleFonts.poppins())),
+                        content: Text('Clé API mise à jour.',
+                            style: GoogleFonts.poppins()),
+                      ),
                     );
                   }
                 }
@@ -154,21 +151,19 @@ class _SettingsState extends State<Settings> {
               style: GoogleFonts.poppins()),
           actions: [
             TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
+              onPressed: () => Navigator.of(context).pop(),
               child: const Text('Annuler'),
             ),
             ElevatedButton(
               onPressed: () async {
-                await prefs.remove(
-                    'chat_history'); // Supprime l'historique (clé fictive)
+                await prefs.remove('chat_history');
                 if (context.mounted) {
                   Navigator.of(context).pop();
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
-                        content: Text('Historique effacé.',
-                            style: GoogleFonts.poppins())),
+                      content: Text('Historique effacé.',
+                          style: GoogleFonts.poppins()),
+                    ),
                   );
                 }
               },

--- a/lib/providers/focus_provider.dart
+++ b/lib/providers/focus_provider.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import '../models/focus_session.dart';
+import '../services/local_db_service.dart';
 
 class FocusProvider extends ChangeNotifier {
+  final _db = LocalDatabaseService();
   Timer? _timer;
   int _secondsRemaining = 25 * 60; // 25 minutes par défaut
+  int _initialMinutes = 25;
   bool _isActive = false;
   int _completedCycles = 0;
 
@@ -21,17 +25,20 @@ class FocusProvider extends ChangeNotifier {
     if (_isActive) return;
     
     if (minutes != null) {
+      _initialMinutes = minutes;
       _secondsRemaining = minutes * 60;
     }
 
     _isActive = true;
-    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) async {
       if (_secondsRemaining > 0) {
         _secondsRemaining--;
         notifyListeners();
       } else {
         stopTimer();
         _completedCycles++;
+        // Sauvegarder la session en base de données
+        await _db.insertFocusSession(FocusSession(durationMinutes: _initialMinutes));
         notifyListeners();
       }
     });

--- a/lib/providers/stats_provider.dart
+++ b/lib/providers/stats_provider.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import '../models/todo_task.dart';
+import '../models/focus_session.dart';
+import '../services/local_db_service.dart';
+
+class StatsProvider extends ChangeNotifier {
+  final _db = LocalDatabaseService();
+  
+  List<TodoTask> _completedTasks = [];
+  List<FocusSession> _focusSessions = [];
+  bool _isLoading = false;
+
+  List<TodoTask> get completedTasks => _completedTasks;
+  List<FocusSession> get focusSessions => _focusSessions;
+  bool get isLoading => _isLoading;
+
+  Future<void> loadStats() async {
+    _isLoading = true;
+    notifyListeners();
+
+    final allTasks = await _db.getTasks();
+    _completedTasks = allTasks.where((t) => t.isCompleted).toList();
+    _focusSessions = await _db.getFocusSessions();
+
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  // Agrégation par jour pour les 7 derniers jours
+  Map<DateTime, int> getTasksPerDay() {
+    final Map<DateTime, int> data = {};
+    final now = DateTime.now();
+    
+    for (int i = 0; i < 7; i++) {
+      final date = DateTime(now.year, now.month, now.day - i);
+      data[date] = 0;
+    }
+
+    for (var task in _completedTasks) {
+      if (task.completedAt != null) {
+        final date = DateTime(task.completedAt!.year, task.completedAt!.month, task.completedAt!.day);
+        if (data.containsKey(date)) {
+          data[date] = data[date]! + 1;
+        }
+      }
+    }
+    return data;
+  }
+
+  Map<DateTime, int> getFocusMinutesPerDay() {
+    final Map<DateTime, int> data = {};
+    final now = DateTime.now();
+    
+    for (int i = 0; i < 7; i++) {
+      final date = DateTime(now.year, now.month, now.day - i);
+      data[date] = 0;
+    }
+
+    for (var session in _focusSessions) {
+      final date = DateTime(session.createdAt.year, session.createdAt.month, session.createdAt.day);
+      if (data.containsKey(date)) {
+        data[date] = data[date]! + session.durationMinutes;
+      }
+    }
+    return data;
+  }
+}

--- a/lib/providers/task_provider.dart
+++ b/lib/providers/task_provider.dart
@@ -24,7 +24,11 @@ class TaskProvider extends ChangeNotifier {
   }
 
   Future<void> toggleTask(TodoTask task) async {
-    final updatedTask = task.copyWith(isCompleted: !task.isCompleted);
+    final isNowCompleted = !task.isCompleted;
+    final updatedTask = task.copyWith(
+      isCompleted: isNowCompleted,
+      completedAt: isNowCompleted ? DateTime.now() : null,
+    );
     await _db.updateTask(updatedTask);
     await loadTasks();
   }

--- a/lib/screens/chatscreen.dart
+++ b/lib/screens/chatscreen.dart
@@ -3,6 +3,7 @@ import 'package:ai_test/screens/enhanced_api_key_widget.dart';
 import 'package:ai_test/screens/enhanced_chat_widget.dart';
 import 'package:ai_test/screens/journal_screen.dart';
 import 'package:ai_test/screens/focus_screen.dart';
+import 'package:ai_test/screens/stats_screen.dart';
 import 'package:ai_test/services/api_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -63,9 +64,16 @@ class _ChatScreenState extends State<ChatScreen> {
       const DashboardScreen(),
       const JournalScreen(),
       const FocusScreen(),
+      const StatsScreen(),
     ];
 
-    final List<String> titles = ['FocusFlow Chat', 'Mes Tâches', 'Mon Journal', 'Focus Mode'];
+    final List<String> titles = [
+      'FocusFlow Chat',
+      'Mes Tâches',
+      'Mon Journal',
+      'Focus Mode',
+      'Statistiques'
+    ];
 
     return Scaffold(
       appBar: AppBar(
@@ -119,6 +127,11 @@ class _ChatScreenState extends State<ChatScreen> {
               icon: Icon(Icons.timer_outlined),
               selectedIcon: Icon(Icons.timer),
               label: 'Focus',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.bar_chart_outlined),
+              selectedIcon: Icon(Icons.bar_chart),
+              label: 'Stats',
             ),
           ],
         ),

--- a/lib/screens/stats_screen.dart
+++ b/lib/screens/stats_screen.dart
@@ -1,0 +1,231 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:google_fonts/google_fonts.dart';
+import '../providers/stats_provider.dart';
+
+class StatsScreen extends StatelessWidget {
+  const StatsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    
+    return Consumer<StatsProvider>(
+      builder: (context, statsProvider, child) {
+        if (statsProvider.isLoading) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final tasksData = statsProvider.getTasksPerDay();
+        final focusData = statsProvider.getFocusMinutesPerDay();
+
+        return RefreshIndicator(
+          onRefresh: () => statsProvider.loadStats(),
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildSummaryCards(statsProvider, theme),
+              const SizedBox(height: 24),
+              _buildChartSection(
+                title: 'Tâches terminées (7 jours)',
+                chart: _TasksBarChart(data: tasksData, color: theme.primaryColor),
+                theme: theme,
+              ),
+              const SizedBox(height: 24),
+              _buildChartSection(
+                title: 'Minutes de Focus (7 jours)',
+                chart: _FocusLineChart(data: focusData, color: theme.primaryColor),
+                theme: theme,
+              ),
+              const SizedBox(height: 100), // Espace pour la barre de navigation
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSummaryCards(StatsProvider stats, ThemeData theme) {
+    return Row(
+      children: [
+        Expanded(
+          child: _StatCard(
+            label: 'Total Tâches',
+            value: stats.completedTasks.length.toString(),
+            icon: Icons.check_circle_outline,
+            color: Colors.green,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: _StatCard(
+            label: 'Sessions Focus',
+            value: stats.focusSessions.length.toString(),
+            icon: Icons.timer_outlined,
+            color: theme.primaryColor,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChartSection({required String title, required Widget chart, required ThemeData theme}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 8, bottom: 16),
+          child: Text(
+            title,
+            style: GoogleFonts.poppins(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+        ),
+        Container(
+          height: 250,
+          padding: const EdgeInsets.fromLTRB(16, 24, 16, 12),
+          decoration: BoxDecoration(
+            color: theme.cardTheme.color,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: theme.dividerColor.withValues(alpha: 0.1)),
+          ),
+          child: chart,
+        ),
+      ],
+    );
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  final String label;
+  final String value;
+  final IconData icon;
+  final Color color;
+
+  const _StatCard({required this.label, required this.value, required this.icon, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Icon(icon, color: color, size: 28),
+            const SizedBox(height: 8),
+            Text(value, style: GoogleFonts.poppins(fontSize: 20, fontWeight: FontWeight.bold)),
+            Text(label, style: GoogleFonts.poppins(fontSize: 12, color: Colors.grey)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TasksBarChart extends StatelessWidget {
+  final Map<DateTime, int> data;
+  final Color color;
+
+  const _TasksBarChart({required this.data, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    final sortedKeys = data.keys.toList()..sort();
+    
+    return BarChart(
+      BarChartData(
+        alignment: BarChartAlignment.spaceAround,
+        maxY: (data.values.fold(0, (prev, curr) => curr > prev ? curr : prev) + 1).toDouble(),
+        barGroups: List.generate(sortedKeys.length, (index) {
+          final date = sortedKeys[index];
+          return BarChartGroupData(
+            x: index,
+            barRods: [
+              BarChartRodData(
+                toY: data[date]!.toDouble(),
+                color: color,
+                width: 16,
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ],
+          );
+        }),
+        titlesData: FlTitlesData(
+          show: true,
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              getTitlesWidget: (value, meta) {
+                final date = sortedKeys[value.toInt()];
+                return Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text('${date.day}/${date.month}', style: const TextStyle(fontSize: 10, color: Colors.grey)),
+                );
+              },
+            ),
+          ),
+          leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        ),
+        gridData: const FlGridData(show: false),
+        borderData: FlBorderData(show: false),
+      ),
+    );
+  }
+}
+
+class _FocusLineChart extends StatelessWidget {
+  final Map<DateTime, int> data;
+  final Color color;
+
+  const _FocusLineChart({required this.data, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    final sortedKeys = data.keys.toList()..sort();
+    
+    return LineChart(
+      LineChartData(
+        gridData: const FlGridData(show: false),
+        titlesData: FlTitlesData(
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              getTitlesWidget: (value, meta) {
+                if (value % 1 != 0) return const SizedBox();
+                final index = value.toInt();
+                if (index < 0 || index >= sortedKeys.length) return const SizedBox();
+                final date = sortedKeys[index];
+                return Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text('${date.day}/${date.month}', style: const TextStyle(fontSize: 10, color: Colors.grey)),
+                );
+              },
+            ),
+          ),
+          leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        ),
+        borderData: FlBorderData(show: false),
+        lineBarsData: [
+          LineChartBarData(
+            spots: List.generate(sortedKeys.length, (index) {
+              return FlSpot(index.toDouble(), data[sortedKeys[index]]!.toDouble());
+            }),
+            isCurved: true,
+            color: color,
+            barWidth: 4,
+            isStrokeCapRound: true,
+            dotData: const FlDotData(show: true),
+            belowBarData: BarAreaData(
+              show: true,
+              color: color.withValues(alpha: 0.1),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -101,9 +101,10 @@ class ApiService {
           '3. **Zéro Culpabilité** : Si une tâche est en retard, dis "C\'est pas grave, le plan change. On fait quoi maintenant ?". '
           '4. **Body Doubling** : Utilise le "On" ou "Nous". Dis "On s\'y met ensemble". '
           '5. **Dopamine Hit** : Célèbre chaque petite victoire. '
-          '6. **Accès Local** : Utilise \'ajouter_tache\', \'lister_taches\', \'terminer_tache\' pour agir. '
-          '7. **Brain Dump** : Si l\'utilisateur divague, utilise \'ajouter_journal\' pour capturer l\'idée et ramène-le au focus actuel. '
-          '8. **Mode Urgence** : Si l\'utilisateur est submergé, propose-lui de fermer les yeux et de lancer un Focus de 5 min via \'lancer_focus\'.'
+          '6. **Zéro Émoji** : N\'utilise JAMAIS d\'émojis dans tes réponses. Utilise uniquement du texte, du gras et des listes. '
+          '7. **Accès Local** : Utilise \'ajouter_tache\', \'lister_taches\', \'terminer_tache\' pour agir. '
+          '8. **Brain Dump** : Si l\'utilisateur divague, utilise \'ajouter_journal\' pour capturer l\'idée et ramène-le au focus actuel. '
+          '9. **Mode Urgence** : Si l\'utilisateur est submergé, propose-lui de fermer les yeux et de lancer un Focus de 5 min via \'lancer_focus\'.'
         ),
       );
 

--- a/lib/services/local_db_service.dart
+++ b/lib/services/local_db_service.dart
@@ -4,6 +4,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:path/path.dart';
 import '../models/todo_task.dart';
 import '../models/journal_entry.dart';
+import '../models/focus_session.dart';
 
 class LocalDatabaseService {
   static final LocalDatabaseService _instance = LocalDatabaseService._internal();
@@ -28,8 +29,9 @@ class LocalDatabaseService {
     String path = join(await getDatabasesPath(), 'productivity.db');
     return await openDatabase(
       path,
-      version: 1,
+      version: 2,
       onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
     );
   }
 
@@ -41,6 +43,7 @@ class LocalDatabaseService {
         description TEXT,
         isCompleted INTEGER DEFAULT 0,
         createdAt TEXT NOT NULL,
+        completedAt TEXT,
         estimatedMinutes INTEGER DEFAULT 15,
         urgency INTEGER DEFAULT 3,
         subTasks TEXT
@@ -65,6 +68,39 @@ class LocalDatabaseService {
         createdAt TEXT NOT NULL
       )
     ''');
+
+    await db.execute('''
+      CREATE TABLE focus_sessions(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        durationMinutes INTEGER NOT NULL,
+        createdAt TEXT NOT NULL
+      )
+    ''');
+  }
+
+  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    if (oldVersion < 2) {
+      await db.execute('ALTER TABLE tasks ADD COLUMN completedAt TEXT');
+      await db.execute('''
+        CREATE TABLE focus_sessions(
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          durationMinutes INTEGER NOT NULL,
+          createdAt TEXT NOT NULL
+        )
+      ''');
+    }
+  }
+
+  // Opérations Focus
+  Future<int> insertFocusSession(FocusSession session) async {
+    final db = await database;
+    return await db.insert('focus_sessions', session.toMap());
+  }
+
+  Future<List<FocusSession>> getFocusSessions() async {
+    final db = await database;
+    final List<Map<String, dynamic>> maps = await db.query('focus_sessions', orderBy: 'createdAt DESC');
+    return List.generate(maps.length, (i) => FocusSession.fromMap(maps[i]));
   }
 
   // Opérations Chat

--- a/lib/services/logger_service.dart
+++ b/lib/services/logger_service.dart
@@ -8,7 +8,7 @@ class AppLogger {
       errorMethodCount: 8,
       lineLength: 120,
       colors: true,
-      printEmojis: true,
+      printEmojis: false,
     ),
   );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.15"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -257,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.11.13"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   flutter_local_notifications: ^22.3.0
   timezone: ^0.11.1
   sqflite_common_ffi: ^2.4.2+1
+  fl_chart: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces several new features and enhancements focused on statistics tracking, theming improvements, and data modeling. The key changes include the addition of a statistics provider to aggregate productivity data, improvements to the theming system to support dynamic font sizing, and updates to the data models and providers to better track task and focus session completion.

**Statistics and Data Aggregation:**

* Introduced a new `StatsProvider` that loads completed tasks and focus sessions from the database, and provides aggregation methods for tasks and focus minutes per day over the last 7 days. (`lib/providers/stats_provider.dart`)
* Registered the `StatsProvider` in the main app and ensured it loads statistics on startup. (`lib/main.dart`) [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R1) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R34)
* Added the `stats_screen.dart` to the app's imports for future statistics UI. (`lib/screens/chatscreen.dart`)

**Focus Session Tracking:**

* Created a new `FocusSession` model to represent individual focus sessions with duration and creation date. (`lib/models/focus_session.dart`)
* Enhanced `FocusProvider` to save each completed focus session to the database when a timer completes. (`lib/providers/focus_provider.dart`) [[1]](diffhunk://#diff-455ea0790680ea6909edec0c3c2b3ff91bda79125fc1389a5c1f06fe4d2bb96cR3-R10) [[2]](diffhunk://#diff-455ea0790680ea6909edec0c3c2b3ff91bda79125fc1389a5c1f06fe4d2bb96cR28-R41)

**Task Completion Tracking:**

* Updated the `TodoTask` model to include a `completedAt` field, enabling tracking of when a task was finished. (`lib/models/todo_task.dart`) [[1]](diffhunk://#diff-c8c133092b9a425fd1685c6288c5d89b3eca4a72e80583a4b065b1ec6300fc67R9) [[2]](diffhunk://#diff-c8c133092b9a425fd1685c6288c5d89b3eca4a72e80583a4b065b1ec6300fc67R20) [[3]](diffhunk://#diff-c8c133092b9a425fd1685c6288c5d89b3eca4a72e80583a4b065b1ec6300fc67R33) [[4]](diffhunk://#diff-c8c133092b9a425fd1685c6288c5d89b3eca4a72e80583a4b065b1ec6300fc67R47) [[5]](diffhunk://#diff-c8c133092b9a425fd1685c6288c5d89b3eca4a72e80583a4b065b1ec6300fc67R60) [[6]](diffhunk://#diff-c8c133092b9a425fd1685c6288c5d89b3eca4a72e80583a4b065b1ec6300fc67R71)
* Modified `TaskProvider.toggleTask` to set or clear the `completedAt` timestamp when toggling task completion. (`lib/providers/task_provider.dart`)

**Theming and UI Improvements:**

* Refactored `AppThemes` to accept a `fontSizeFactor` parameter, allowing dynamic scaling of font sizes throughout the app's light and dark themes. (`lib/others/app_theme.dart`, `lib/main.dart`) [[1]](diffhunk://#diff-21a769462fcd61818ddea1bed850790d9f6c75fadd887fa6ab1703cafdbe913dL154-R168) [[2]](diffhunk://#diff-21a769462fcd61818ddea1bed850790d9f6c75fadd887fa6ab1703cafdbe913dL178-R183) [[3]](diffhunk://#diff-21a769462fcd61818ddea1bed850790d9f6c75fadd887fa6ab1703cafdbe913dR193) [[4]](diffhunk://#diff-21a769462fcd61818ddea1bed850790d9f6c75fadd887fa6ab1703cafdbe913dL202-R206) [[5]](diffhunk://#diff-21a769462fcd61818ddea1bed850790d9f6c75fadd887fa6ab1703cafdbe913dL221-R237) [[6]](diffhunk://#diff-21a769462fcd61818ddea1bed850790d9f6c75fadd887fa6ab1703cafdbe913dL256-R260) [[7]](diffhunk://#diff-21a769462fcd61818ddea1bed850790d9f6c75fadd887fa6ab1703cafdbe913dR270) [[8]](diffhunk://#diff-21a769462fcd61818ddea1bed850790d9f6c75fadd887fa6ab1703cafdbe913dL275-R283) [[9]](diffhunk://#diff-21a769462fcd61818ddea1bed850790d9f6c75fadd887fa6ab1703cafdbe913dL294-R303) [[10]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L51-R54)

**Settings and Code Clean-up:**

* Simplified and cleaned up dialog actions and variable usage in the `Settings` page for better readability and maintainability. (`lib/pages/settings.dart`) [[1]](diffhunk://#diff-1eadbad4e419656bcecb919016a126d365c0f5f1a893fbd0f8462f36e947864cL45-R47) [[2]](diffhunk://#diff-1eadbad4e419656bcecb919016a126d365c0f5f1a893fbd0f8462f36e947864cL69-R75) [[3]](diffhunk://#diff-1eadbad4e419656bcecb919016a126d365c0f5f1a893fbd0f8462f36e947864cL115-R113) [[4]](diffhunk://#diff-1eadbad4e419656bcecb919016a126d365c0f5f1a893fbd0f8462f36e947864cL129-R126) [[5]](diffhunk://#diff-1eadbad4e419656bcecb919016a126d365c0f5f1a893fbd0f8462f36e947864cL157-R166)