### PR TITLE
Add tests for API service, models, and providers

### DIFF
--- a/test/api_service_test.dart
+++ b/test/api_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ai_test/services/api_service.dart';
+
+void main() {
+  group('ApiService', () {
+    late ApiService apiService;
+
+    setUp(() {
+      apiService = ApiService();
+    });
+
+    test('isInitialized should be false initially', () {
+      expect(apiService.isInitialized, false);
+    });
+
+    test('sendMessage should throw if not initialized', () async {
+      expect(
+        () => apiService.sendMessage('hello'),
+        throwsA(isA<ApiServiceException>()),
+      );
+    });
+
+    test('getHistory should return empty if not initialized', () {
+      expect(apiService.getHistory(), isEmpty);
+    });
+  });
+}

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ai_test/models/todo_task.dart';
 import 'package:ai_test/models/journal_entry.dart';
 import 'package:ai_test/models/focus_session.dart';
+import 'package:ai_test/models/chat_message.dart';
 
 void main() {
   group('TodoTask Model', () {
@@ -61,6 +62,22 @@ void main() {
       final fromMap = FocusSession.fromMap(map);
       
       expect(fromMap.durationMinutes, 25);
+    });
+  });
+
+  group('ChatMessage Model', () {
+    test('should create instance correctly', () {
+      final message = ChatMessage(text: 'Hello', isFromUser: true);
+      expect(message.text, 'Hello');
+      expect(message.isFromUser, true);
+      expect(message.timestamp, isA<DateTime>());
+    });
+
+    test('error factory should create error message', () {
+      final message = ChatMessage.error('Some error');
+      expect(message.text, 'Some error');
+      expect(message.isFromUser, false);
+      expect(message.error, 'Some error');
     });
   });
 }

--- a/test/profile_provider_test.dart
+++ b/test/profile_provider_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ai_test/providers/profile_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('ProfileProvider', () {
+    late ProfileProvider profileProvider;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      profileProvider = ProfileProvider();
+    });
+
+    test('Initial state should be default values', () async {
+      // Need to wait for initialize inside the constructor or call loadProfile
+      await profileProvider.loadProfile();
+      expect(profileProvider.userName, 'Utilisateur');
+      expect(profileProvider.userBio, 'Prêt à rester concentré');
+    });
+
+    test('updateProfile should update state and save to prefs', () async {
+      await profileProvider.updateProfile(name: 'New Name', bio: 'New Bio');
+      
+      expect(profileProvider.userName, 'New Name');
+      expect(profileProvider.userBio, 'New Bio');
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('profile_name'), 'New Name');
+      expect(prefs.getString('profile_bio'), 'New Bio');
+    });
+  });
+}

--- a/test/task_provider_test.dart
+++ b/test/task_provider_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ai_test/providers/task_provider.dart';
+import 'package:ai_test/services/local_db_service.dart';
+import 'package:ai_test/models/todo_task.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockLocalDatabaseService extends Mock implements LocalDatabaseService {}
+class FakeTodoTask extends Fake implements TodoTask {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeTodoTask());
+  });
+
+  group('TaskProvider', () {
+    late TaskProvider taskProvider;
+    late MockLocalDatabaseService mockDb;
+
+    setUp(() {
+      mockDb = MockLocalDatabaseService();
+      taskProvider = TaskProvider(db: mockDb);
+    });
+
+    test('loadTasks should update tasks list', () async {
+      final tasks = [TodoTask(title: 'Test Task')];
+      when(() => mockDb.getTasks()).thenAnswer((_) async => tasks);
+      
+      await taskProvider.loadTasks();
+      
+      expect(taskProvider.tasks.length, 1);
+      expect(taskProvider.tasks.first.title, 'Test Task');
+      expect(taskProvider.isLoading, false);
+    });
+
+    test('addTask should call database insert and reload', () async {
+      final task = TodoTask(title: 'New Task');
+      when(() => mockDb.insertTask(any())).thenAnswer((_) async => 1);
+      when(() => mockDb.getTasks()).thenAnswer((_) async => [task]);
+      
+      await taskProvider.addTask(task);
+      
+      verify(() => mockDb.insertTask(task)).called(1);
+      expect(taskProvider.tasks.length, 1);
+    });
+
+    test('toggleTask should update task completion and reload', () async {
+      final task = TodoTask(id: 1, title: 'Task', isCompleted: false);
+      when(() => mockDb.updateTask(any())).thenAnswer((_) async => 1);
+      when(() => mockDb.getTasks()).thenAnswer((_) async => [task.copyWith(isCompleted: true)]);
+      
+      await taskProvider.toggleTask(task);
+      
+      verify(() => mockDb.updateTask(any())).called(1);
+      expect(taskProvider.tasks.first.isCompleted, true);
+    });
+  });
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several core components of the application, focusing on service, model, and provider logic. The main changes include new tests for `ApiService`, `ProfileProvider`, and `TaskProvider`, as well as improved model coverage for `ChatMessage`.

### New and Improved Unit Tests

**Service Layer:**
* Added a new test suite for `ApiService` in `test/api_service_test.dart`, verifying initialization state, error handling, and history behavior.

**Provider Layer:**
* Added a new test suite for `ProfileProvider` in `test/profile_provider_test.dart`, including tests for default state, profile updating, and persistence with `SharedPreferences`.
* Added a new test suite for `TaskProvider` in `test/task_provider_test.dart`, using a mocked local database to test loading, adding, and toggling tasks.

**Model Layer:**
* Added import and unit tests for the `ChatMessage` model in `test/models_test.dart`, testing creation and error factory behavior. [[1]](diffhunk://#diff-772a06e21bc54537a5a8234e068ae4f1b2066dcabbcd624bf00ab618275fe745R5) [[2]](diffhunk://#diff-772a06e21bc54537a5a8234e068ae4f1b2066dcabbcd624bf00ab618275fe745R67-R82)

These changes significantly increase test coverage and ensure that critical logic in services, providers, and models behaves as expected.